### PR TITLE
Fix nav bar categories all_categories not showing

### DIFF
--- a/components/header-mega-menu.jinja
+++ b/components/header-mega-menu.jinja
@@ -3,40 +3,53 @@
     <div class="container">
         <div class="top-main-menu-wrapper">
             <nav role="navigation" class="d-flex flex-grow-1 main-nav-wrapper">
-                <ul class="main-nav d-flex flex-grow-1 flex-wrap menu-header-theme-text-for-primary-bg">
-                    
-                    {% for menu in store.settings.menus.main_menu.items %}
-                        {% if menu.url %}
-                            <li class="top-level-link {% if menu.slug == 'all_categories' %} all-categories {% endif %}" >
-                                <a href="{{ menu.url | localized_url if menu.resource_type != 'url' else menu.url }}"
-                                        {% if menu.items | length > 0 %} class="mega-menu" {% endif %} ><span>{{ menu.label }}</span></a>
-                                {% if menu.items | length > 0 %}
-                                    <div class="sub-menu-block">
-                                        <div class="row">
-                                            {% for menu_sub in menu.items %}
-                                                <div class="col-md-4 col-lg-4 col-sm-4">
-                                                    {% if menu_sub.items | length > 0 %}
-                                                        <h5 class="sub-menu-head">
-                                                            <a style="font-size: 1.16rem; color: inherit" href="{{ menu_sub.url | localized_url if menu_sub.resource_type != 'url' else menu_sub.url}}">{{ menu_sub.label }}</a>
-                                                        </h5>
-                                                        <ul class="sub-menu-lists">
-                                                            {% for menu_sub_sub in menu_sub.items %}
-                                                                <li><a href="{{ menu_sub_sub.url | localized_url if menu_sub_sub.resource_type != 'url' else menu_sub_sub.url  }}">{{ menu_sub_sub.label }}</a></li>
-                                                            {% endfor %}
-                                                        </ul>
-                                                    {% else %}
-                                                        <h2 class="sub-menu-head"><a style="font-size: 1.16rem; color: inherit" href="{{ menu_sub.url | localized_url if menu_sub.resource_type != 'url' else menu_sub.url }}">{{ menu_sub.label }}</a></h2>
-                                                    {% endif %}
-                                                </div>
-                                            {% endfor %}
-                                        </div>
+                <ul class="main-nav d-flex flex-grow-1 flex-wrap menu-header-theme-text-for-primary-bg">                 
+                {% set total = store.settings.menus.main_menu.items | length %}
+                {% set n = 5 %} {# number of first items to show #}
+                {% for menu in store.settings.menus.main_menu.items %}
+                    {% if loop.index0 < n or loop.index0 == total - 1 %}
+                        <li class="top-level-link {% if menu.slug == 'all_categories' %} all-categories {% endif %}">
+                            <a href="{{ menu.url | localized_url if menu.resource_type != 'url' else menu.url }}"
+                                {% if menu.items | length > 0 %} class="mega-menu" {% endif %}>
+                                <span>{{ menu.label }}</span>
+                            </a>
+                            {% if menu.items | length > 0 %}
+                                <div class="sub-menu-block">
+                                    <div class="row">
+                                        {% for menu_sub in menu.items %}
+                                            <div class="col-md-4 col-lg-4 col-sm-4">
+                                                {% if menu_sub.items | length > 0 %}
+                                                    <h5 class="sub-menu-head">
+                                                        <a style="font-size: 1.16rem; color: inherit"
+                                                        href="{{ menu_sub.url | localized_url if menu_sub.resource_type != 'url' else menu_sub.url }}">
+                                                            {{ menu_sub.label }}
+                                                        </a>
+                                                    </h5>
+                                                    <ul class="sub-menu-lists">
+                                                        {% for menu_sub_sub in menu_sub.items %}
+                                                            <li>
+                                                                <a href="{{ menu_sub_sub.url | localized_url if menu_sub_sub.resource_type != 'url' else menu_sub_sub.url }}">
+                                                                    {{ menu_sub_sub.label }}
+                                                                </a>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% else %}
+                                                    <h2 class="sub-menu-head">
+                                                        <a style="font-size: 1.16rem; color: inherit"
+                                                        href="{{ menu_sub.url | localized_url if menu_sub.resource_type != 'url' else menu_sub.url }}">
+                                                            {{ menu_sub.label }}
+                                                        </a>
+                                                    </h2>
+                                                {% endif %}
+                                            </div>
+                                        {% endfor %}
                                     </div>
-                                {% endif %}
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-
-
+                                </div>
+                            {% endif %}
+                        </li>
+                    {% endif %}
+                {% endfor %}
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
# Description

Currently when merchant has more than 6+ categories , the css we have I assume will hide them. So for now a solution to keep the "جميع التصنيفات" in the navbar is to truncate the list of menu items in and keep the last item which is the "All Categories" item.


### Jira Ticket

https://zid-dev.atlassian.net/browse/INCIDENT-10430

### Additional Notes (Optional)


