### PR TITLE
Lazy load bundle offers

### DIFF
--- a/assets/bundle-offers.js
+++ b/assets/bundle-offers.js
@@ -64,6 +64,14 @@ class BundleOffersLoader {
       if (bundleOffer && bundleOffer.name) {
         el.textContent = bundleOffer.name;
         el.classList.add('bundle-offer-product-tag');
+
+        // Check if there's a badge sibling and adjust position
+        const parent = el.parentElement;
+        const badge = parent ? parent.querySelector('[class*="badge"]') : null;
+        if (badge && badge !== el) {
+          el.style.top = '45px';
+        }
+
         this.loadedOffers.set(productId, bundleOffer);
       }
     });

--- a/assets/bundle-offers.js
+++ b/assets/bundle-offers.js
@@ -1,0 +1,120 @@
+/**
+ * Bundle Offers Loader
+ * Fetches and displays bundle offers for products in lists
+ */
+
+class BundleOffersLoader {
+  constructor() {
+    this.baseUrl = window.location.origin;
+    this.loadedOffers = new Map();
+  }
+
+  /**
+   * Collect all product IDs that need bundle offer data
+   */
+  collectProductIds() {
+    const productIds = new Set();
+    const elements = document.querySelectorAll('.product-card-bundle-offer[data-bundle-offer-product-id]');
+
+    elements.forEach(el => {
+      const productId = el.getAttribute('data-bundle-offer-product-id');
+      if (productId && !this.loadedOffers.has(productId)) {
+        productIds.add(productId);
+      }
+    });
+
+    return Array.from(productIds);
+  }
+
+  /**
+   * Fetch bundle offers for a list of product IDs
+   */
+  async fetchBundleOffers(productIds) {
+    if (!productIds || productIds.length === 0) {
+      return null;
+    }
+
+    const params = productIds.map(id => `product_ids=${id}`).join('&');
+    const url = `${this.baseUrl}/api/v1/products/bundle-offers?${params}`;
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        console.error('Failed to fetch bundle offers:', response.status);
+        return null;
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error('Error fetching bundle offers:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Display bundle offer on product card
+   */
+  displayBundleOffer(productId, bundleOffer) {
+    const elements = document.querySelectorAll(
+      `.product-card-bundle-offer[data-bundle-offer-product-id="${productId}"]`
+    );
+
+    elements.forEach(el => {
+      if (bundleOffer && bundleOffer.name) {
+        el.textContent = bundleOffer.name;
+        el.classList.add('bundle-offer-product-tag');
+        this.loadedOffers.set(productId, bundleOffer);
+      }
+    });
+  }
+
+  /**
+   * Load and display bundle offers for all products on the page
+   */
+  async loadBundleOffers() {
+    const productIds = this.collectProductIds();
+
+    if (productIds.length === 0) {
+      return;
+    }
+
+    const bundleOffersData = await this.fetchBundleOffers(productIds);
+
+    if (bundleOffersData && bundleOffersData.payload) {
+      bundleOffersData.payload.forEach(bundleOffer => {
+        if (bundleOffer.product_ids && bundleOffer.product_ids.length > 0) {
+          // Each bundle offer can apply to multiple products
+          bundleOffer.product_ids.forEach(productId => {
+            this.displayBundleOffer(productId, bundleOffer);
+          });
+        }
+      });
+    }
+  }
+
+  /**
+   * Initialize the loader
+   */
+  init() {
+    // Load bundle offers when DOM is ready
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.loadBundleOffers());
+    } else {
+      this.loadBundleOffers();
+    }
+  }
+
+  /**
+   * Reload bundle offers (useful after dynamic content updates)
+   */
+  reload() {
+    this.loadBundleOffers();
+  }
+}
+
+// Create global instance
+window.bundleOffersLoader = new BundleOffersLoader();
+
+// Auto-initialize
+window.bundleOffersLoader.init();

--- a/assets/main.css
+++ b/assets/main.css
@@ -2072,9 +2072,9 @@ hr {
     display: none;
     position: absolute;
     left: 15px;
-    top:15px;
+    top: 15px;
     max-width: 80%;
-    padding: 4px  7px;
+    padding: 4px 7px;
     color: var(--text-color-primary-bg);
     background-color: var(--primary-color);
     font-size: 12px;
@@ -2084,6 +2084,7 @@ hr {
     text-overflow: ellipsis;
 
     border-radius: 5px;
+    z-index: 1;
 }
 
 .rtl .product-card-bundle-offer {
@@ -2091,6 +2092,10 @@ hr {
     right: 15px;
 }
 
+/* Stack bundle offer below badge if badge exists */
+.product-item .box-1-1 .content > [class*="badge"]:first-child ~ .product-card-bundle-offer {
+    top: 45px;
+}
 
 .product-card-bundle-offer.bundle-offer-product-tag {
     display: inline-block;

--- a/layout.jinja
+++ b/layout.jinja
@@ -248,6 +248,7 @@
 <script src="{{ 'slide-menu.ie.js?v=1.06' | asset_url }}"></script>
 
 <script type="text/javascript" src="{{ ('main.js?v=' ~ ver) | asset_url }}" defer></script>
+<script type="text/javascript" src="{{ ('bundle-offers.js?v=' ~ ver) | asset_url }}" defer></script>
 
 {% vitrin_body %}
 

--- a/layout.jinja
+++ b/layout.jinja
@@ -1,4 +1,4 @@
-{% set ver = '0.1.020' %}
+{% set ver = '0.1.022' %}
 <!doctype html>
 <html class="no-js" lang="{{ session.lang }}" dir="{{ session.locale.language.direction }}">
 
@@ -130,7 +130,7 @@
 
     <link rel="stylesheet" type="text/css" href="{{ 'slide-menu-style.css?v=1.16' | asset_url }}" />
 
-    <link rel="stylesheet" href="{{ 'main.css?v=1.228' | asset_url }}" />
+    <link rel="stylesheet" href="{{ ('main.css?v=' ~ ver) | asset_url }}" />
 
     <link rel="stylesheet" type="text/css" href="{{ 'custom.css?v=1.148' | asset_url }}" />
 

--- a/templates/products.jinja
+++ b/templates/products.jinja
@@ -71,6 +71,10 @@
                 $('#product-pagination').css('opacity', '1');
             }
 
+            // Reload bundle offers for newly loaded products
+            if (window.bundleOffersLoader) {
+                window.bundleOffersLoader.reload();
+            }
         }
 
         {% if  products.data|length > 0 %}


### PR DESCRIPTION
# Description
Because with the new products list endpoint we no longer return bundle offers to improve speed and load time in the products page. So now we just load bundle offers after the page loads to populate the bundle offer tag if found for a product.


### Jira Ticket
https://zid-dev.atlassian.net/browse/CR-27884


### Additional Notes (Optional)


